### PR TITLE
feat(dep): depend on cwd 6to5 first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -1,7 +1,15 @@
 /* jshint node:true */
 
-var to5 = require('6to5');
 var extend = require('util')._extend;
+var resolve = require('resolve');
+
+var to5;
+try {
+  to5 = require(resolve.sync('6to5', { basedir: process.cwd() }));
+} catch (_) {
+  console.warn('Processing using inner 6to5. version : ' + to5.version);
+  to5 = require('6to5');
+}
 
 var PER_FILE_OPTIONS = [
   'filename',

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   },
   "license": "ISC",
   "dependencies": {
+    "resolve": "^1.0.0"
+  },
+  "devDependencies": {
     "6to5": "^2.0.0"
   }
 }


### PR DESCRIPTION
Many plugins (like [6to5/gulp-6to5](https://github.com/6to5/gulp-6to5) and [6to5/karma-5to5-preprocessor](https://github.com/6to5/karma-6to5-preprocessor)) use their own 6to5 version. 
This can lead to sync problems.

But like **one does not simply use peerDependencies** I'm proposing another way ;)