### PR TITLE
Add `sourceRoot` to per-file options

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var extend = require('util')._extend;
 var PER_FILE_OPTIONS = [
   'filename',
   'sourceMapName',
-  'sourceFileName'
+  'sourceFileName',
+  'sourceRoot'
 ];
 
 function createPreprocessor(args, config, logger, helper) {


### PR DESCRIPTION
Use case:

Main application code is modeled as ES 6 modules, unit test as well. Since they are in different folders, they might need different source root to make their names correct.

## Example

Application code:
`sourceRoot` is in `web/js` -> module in `web/js/utils/type.js` gets name `utils/type`.

Testing code:
`sourceRoot` is in `test/unit` -> module in `test/unit/utils/typeSpec.js` gets name `utils/typeSpec`.

Another thing about this is common need for auto-loading the test modules, do you think it would be of a benefit to include this in the preprocessor? (I myself use another custom preprocessor).